### PR TITLE
multiple fixes in codec and codegen

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The ProtoBuf.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2014: tan.
+> Copyright (c) 2014: Tanmay Mohapatra.
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -22,6 +22,12 @@ import Base.rsplit
 rsplit{T<:String}(str::T, splitter; limit::Integer=0, keep::Bool=true) = rsplit(str, splitter, limit, keep)
 end
 
+if isless(Base.VERSION, v"0.4.0-")
+fld_type(o, fld) = fieldtype(o, fld)
+else
+fld_type(o, fld) = fieldtype(typeof(o), fld)
+end
+
 # enable logging only during debugging
 #using Logging
 #const logger = Logging.configure(filename="protobuf.log", level=DEBUG)

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -324,7 +324,7 @@ function readproto(io::IO, obj, meta::ProtoMeta=meta(typeof(obj)))
         fld = attrib.fld
         if !isfilled(obj, fld) && (length(attrib.default) > 0)
             default = attrib.default[1]
-            setfield!(obj, fld, convert(fieldtype(typeof(obj), fld), deepcopy(default)))
+            setfield!(obj, fld, convert(fld_type(obj, fld), deepcopy(default)))
             fillset(obj, fld)
         end
     end

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -92,7 +92,7 @@ end
 function _read_zigzag{T <: Integer}(io::IO, typ::Type{T})
     zx = _read_uleb(io, UInt64)
     # result is positive if zx is even
-    convert(typ, iseven(zx) ? (zx >>> 1) : -((zx+1) >>> 1))
+    convert(typ, iseven(zx) ? (zx >>> 1) : -signed((zx+1) >>> 1))
 end
 
 
@@ -196,7 +196,7 @@ function _setmeta(meta::ProtoMeta, jtype::Type, ordered::Array{ProtoMetaAttribs,
 end
 
 function writeproto(io::IO, val, attrib::ProtoMetaAttribs)
-    !isempty(attrib.default) && isequal(val, attrib.default[1]) && (return 0)
+    #!isempty(attrib.default) && isequal(val, attrib.default[1]) && (return 0)
     fld = attrib.fldnum
     meta = attrib.meta
     ptyp = attrib.ptyp
@@ -324,7 +324,7 @@ function readproto(io::IO, obj, meta::ProtoMeta=meta(typeof(obj)))
         fld = attrib.fld
         if !isfilled(obj, fld) && (length(attrib.default) > 0)
             default = attrib.default[1]
-            setfield!(obj, fld, deepcopy(default))
+            setfield!(obj, fld, convert(fieldtype(typeof(obj), fld), deepcopy(default)))
             fillset(obj, fld)
         end
     end

--- a/test/services/genproto.sh
+++ b/test/services/genproto.sh
@@ -1,0 +1,1 @@
+protoc --proto_path=. --julia_out=. testsvc.proto

--- a/test/services/testsvc.jl
+++ b/test/services/testsvc.jl
@@ -1,0 +1,206 @@
+using Compat
+import Base: TCPServer, close
+import ProtoBuf: call_method, write_bytes, read_bytes
+
+include("testsvc_pb.jl")
+
+# Out RpcController for the test does nothing as of now
+type TestRpcController <: ProtoRpcController
+    debug::Bool
+end
+
+debug_log(controller::TestRpcController, msg) = controller.debug && println(msg)
+error_log(controller::TestRpcController, msg) = println(STDERR, msg)
+
+# RpcChannel implementation for our test protocol
+# The protocol is to write and read:
+# - messages as delimited bytes
+# - header type SvcHeader to identify the method being called
+type TestRpcChannel <: ProtoRpcChannel
+    sock::TCPSocket
+end
+close(channel::TestRpcChannel) = close(channel.sock)
+
+type SvcHeader
+    method::ASCIIString
+    SvcHeader() = (o=new(); fillunset(o); o)
+end
+
+function write_request(channel::TestRpcChannel, controller::TestRpcController, method::MethodDescriptor, request)
+    io = channel.sock
+    hdr = SvcHeader()
+    set_field(hdr, :method, method.name)
+
+    iob = IOBuffer()
+
+    hdr_len = writeproto(iob, hdr)
+    hdr_buff = takebuf_array(iob)
+
+    data_len = writeproto(iob, request)
+    data_buff = takebuf_array(iob)
+
+    write_bytes(io, hdr_buff)
+    debug_log(controller, "req hdr  ==> $hdr_len bytes: $hdr_buff")
+    write_bytes(io, data_buff)
+    debug_log(controller, "req data ==> $data_len bytes: $data_buff")
+    hdr_len + data_len
+end
+
+function read_request(channel::TestRpcChannel, controller::TestRpcController, srvr)
+    io = channel.sock
+    hdr = SvcHeader()
+    hdr_buff = read_bytes(io)
+    debug_log(controller, "req hdr  <== $(length(hdr_buff)) bytes: $hdr_buff")
+    readproto(IOBuffer(hdr_buff), hdr)
+    method = find_method(srvr, hdr.method)
+
+    request_type = get_request_type(srvr, method)
+    request = request_type()
+    data_buff = read_bytes(io)
+    debug_log(controller, "req data <== $(length(data_buff)) bytes: $data_buff")
+    readproto(IOBuffer(data_buff), request)
+    method, request
+end
+
+function write_response(channel::TestRpcChannel, controller::TestRpcController, response)
+    io = channel.sock
+    iob = IOBuffer()
+    data_len = writeproto(iob, response)
+    data_buff = takebuf_array(iob)
+    write_bytes(io, data_buff)
+    debug_log(controller, "resp ==> $(length(data_buff)) bytes: $data_buff")
+    data_len
+end
+
+function read_response(channel::TestRpcChannel, controller::TestRpcController, response)
+    io = channel.sock
+    data_buff = read_bytes(io)
+    debug_log(controller, "resp <== $(length(data_buff)) bytes: $data_buff")
+    readproto(IOBuffer(data_buff), response)
+    response
+end
+
+function call_method(channel::TestRpcChannel, method::MethodDescriptor, controller::TestRpcController, request)
+    write_request(channel, controller, method, request)
+    response_type = get_response_type(method)
+    response = response_type()
+    read_response(channel, controller, response)
+end
+
+# Test server implementation on the RpcChannel
+# 
+type TestServer
+    srvr::TCPServer
+    impl::ProtoService
+    run::Bool
+    debug::Bool
+    TestServer(port::Integer) = new(listen(port), TestMath(Main), true, false)
+end
+
+function process(srvr::TestServer, channel::TestRpcChannel)
+    controller = TestRpcController(srvr.debug)
+    debug_log(controller, "starting processing from channel")
+
+    try
+        while(!eof(channel.sock))
+            method, request = read_request(channel, controller, srvr.impl)
+            response = call_method(srvr.impl, method, controller, request)
+            debug_log(controller, "response: $response")
+            write_response(channel, controller, response)
+        end
+    catch ex
+        debug_log(controller, "channel stopped with exception $ex")
+    end
+    debug_log(controller, "stopped processing channel")
+end
+
+# implementations of our test services
+function Add(req::BinaryOpReq)
+    resp = BinaryOpResp()
+    set_field(resp, :result, req.i1 + req.i2)
+    resp
+end
+
+function Mul(req::BinaryOpReq)
+    resp = BinaryOpResp()
+    set_field(resp, :result, req.i1 * req.i2)
+    resp
+end
+
+# Utility methods for running the server and client
+function run_server(srvr::TestServer)
+    controller = TestRpcController(srvr.debug)
+    try
+        while(srvr.run)
+            sock = accept(srvr.srvr)
+            channel = TestRpcChannel(sock)
+            @async process(srvr, channel)
+        end
+    catch ex
+        debug_log(controller, "server stopped with exception $ex")
+    end
+    debug_log(controller, "stopped server")
+end
+
+global nresults = 0
+function chk_results(out::BinaryOpResp, expected, channel=nothing)
+    global nresults
+    if channel != nothing
+        close(channel)
+        nresults += 1
+    end
+    @assert out.result == expected
+    nothing
+end
+
+function run_client(debug::Bool)
+    global nresults
+    controller = TestRpcController(debug)
+
+    debug_log(controller, "testing blocking stub")
+    let channel=TestRpcChannel(connect(9999)), stub=TestMathBlockingStub(channel)
+        for i in 1:10
+            inp = BinaryOpReq()
+            set_field(inp, :i1, int64(rand(Int8)))
+            set_field(inp, :i2, int64(rand(Int8)))
+
+            out = Add(stub, controller, inp)
+            chk_results(out, inp.i1+inp.i2)
+
+            out = Mul(stub, controller, inp)
+            chk_results(out, inp.i1*inp.i2)
+        end
+        close(channel)
+    end
+
+    debug_log(controller, "testing non blocking stub")
+    for i in 1:10
+        inp = BinaryOpReq()
+        set_field(inp, :i1, int64(rand(Int8)))
+        set_field(inp, :i2, int64(rand(Int8)))
+       
+        nresults -= 1
+        let channel=TestRpcChannel(connect(9999)), stub=TestMathStub(channel), expected=inp.i1+inp.i2
+            Add(stub, controller, inp, (out)->chk_results(out, expected, channel))
+        end
+
+        nresults -= 1
+        let channel=TestRpcChannel(connect(9999)), stub=TestMathStub(channel), expected=inp.i1*inp.i2
+            Mul(stub, controller, inp, (out)->chk_results(out, expected, channel))
+        end
+    end
+    while nresults != 0
+        debug_log(controller, "waiting for $nresults results")
+        yield()
+        sleep(1)
+    end
+end
+
+debug = true
+srvr = TestServer(9999)
+srvr.debug = debug
+@async run_server(srvr)
+sleep(1)
+run_client(debug)
+srvr.run = false
+close(srvr.srvr)

--- a/test/services/testsvc.proto
+++ b/test/services/testsvc.proto
@@ -1,0 +1,16 @@
+option py_generic_services = true;
+option java_generic_services = true;
+
+message BinaryOpReq {
+    required int64 i1 = 1;
+    required int64 i2 = 2;
+}
+
+message BinaryOpResp {
+    required int64 result = 1;
+}
+
+service TestMath {
+  rpc Mul(BinaryOpReq) returns(BinaryOpResp);
+  rpc Add(BinaryOpReq) returns(BinaryOpResp);
+}

--- a/test/services/testsvc_pb.jl
+++ b/test/services/testsvc_pb.jl
@@ -1,0 +1,44 @@
+using ProtoBuf
+import ProtoBuf.meta
+
+type BinaryOpReq
+    i1::Int64
+    i2::Int64
+    BinaryOpReq() = (o=new(); fillunset(o); o)
+end #type BinaryOpReq
+const __req_BinaryOpReq = Symbol[:i1,:i2]
+meta(t::Type{BinaryOpReq}) = meta(t, __req_BinaryOpReq, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES)
+
+type BinaryOpResp
+    result::Int64
+    BinaryOpResp() = (o=new(); fillunset(o); o)
+end #type BinaryOpResp
+const __req_BinaryOpResp = Symbol[:result]
+meta(t::Type{BinaryOpResp}) = meta(t, __req_BinaryOpResp, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES)
+
+# service methods for TestMath
+const _TestMath_methods = MethodDescriptor[
+        MethodDescriptor("Mul", 1, BinaryOpReq, BinaryOpResp),
+        MethodDescriptor("Add", 2, BinaryOpReq, BinaryOpResp)
+    ] # const _TestMath_methods
+const _TestMath_desc = ServiceDescriptor("TestMath", 1, _TestMath_methods)
+
+TestMath(impl::Module) = ProtoService(_TestMath_desc, impl)
+
+type TestMathStub <: AbstractProtoServiceStub{false}
+    impl::ProtoServiceStub
+    TestMathStub(channel::ProtoRpcChannel) = new(ProtoServiceStub(_TestMath_desc, channel))
+end # type TestMathStub
+
+type TestMathBlockingStub <: AbstractProtoServiceStub{true}
+    impl::ProtoServiceBlockingStub
+    TestMathBlockingStub(channel::ProtoRpcChannel) = new(ProtoServiceBlockingStub(_TestMath_desc, channel))
+end # type TestMathBlockingStub
+
+Mul(stub::TestMathStub, controller::ProtoRpcController, inp::BinaryOpReq, done::Function) = call_method(stub.impl, _TestMath_methods[1], controller, inp, done)
+Mul(stub::TestMathBlockingStub, controller::ProtoRpcController, inp::BinaryOpReq) = call_method(stub.impl, _TestMath_methods[1], controller, inp)
+
+Add(stub::TestMathStub, controller::ProtoRpcController, inp::BinaryOpReq, done::Function) = call_method(stub.impl, _TestMath_methods[2], controller, inp, done)
+Add(stub::TestMathBlockingStub, controller::ProtoRpcController, inp::BinaryOpReq) = call_method(stub.impl, _TestMath_methods[2], controller, inp)
+
+export BinaryOpReq, BinaryOpResp, TestMath, TestMathStub, TestMathBlockingStub, Mul, Add


### PR DESCRIPTION
codec:
- handle changes in `convert` method in Julia 0.4
- `writeproto` now writes fields with default values if they are explicitly set (causes error with some readers otherwise)

codegen:
- do not generate duplicate `using <package>`
- use relative package path with nested packages
- use 0.4 Dict syntax with `@compat`