### PR TITLE
fix serialization of sfixed and fixed types

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -237,6 +237,14 @@ function generate(outio::IO, errio::IO, dtype::DescriptorProto, scope::Scope, ex
                 push!(wtypes, ":$fldname => :sint32")
             elseif field.typ == TYPE_SINT64
                 push!(wtypes, ":$fldname => :sint64")
+            elseif field.typ == TYPE_FIXED32
+                push!(wtypes, ":$fldname => :fixed32")
+            elseif field.typ == TYPE_SFIXED32
+                push!(wtypes, ":$fldname => :sfixed32")
+            elseif field.typ == TYPE_FIXED64
+                push!(wtypes, ":$fldname => :fixed64")
+            elseif field.typ == TYPE_SFIXED64
+                push!(wtypes, ":$fldname => :sfixed64")
             end
             enum_typ_name = (field.typ == TYPE_ENUM) ? typ_name : ""
             (field.typ != TYPE_MESSAGE) && (typ_name = "$(JTYPES[field.typ])")

--- a/src/gen_descriptor_protos.jl
+++ b/src/gen_descriptor_protos.jl
@@ -171,7 +171,7 @@ const TYPE_SFIXED64       = 16
 const TYPE_SINT32         = 17
 const TYPE_SINT64         = 18
 
-const JTYPES              = [Float64, Float32, Int64, UInt64, Int32, Float64, Float32, Bool, AbstractString, Any, Any, Array{UInt8,1}, UInt32, Int32, Float32, Float64, Int32, Int64]
+const JTYPES              = [Float64, Float32, Int64, UInt64, Int32, UInt64,  UInt32,  Bool, AbstractString, Any, Any, Array{UInt8,1}, UInt32, Int32, Int32, Int64, Int32, Int64]
 const JTYPE_DEFAULTS      = [0,       0,       0,     0,      0,     0,       0,       false, "",    nothing, nothing, UInt8[], 0,     0,     0,       0,       0,     0]
 
 const LABEL_OPTIONAL      = 1

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -11,11 +11,11 @@ end
 enum(x) = int(x)
 sint32(x) = int32(x)
 sint64(x) = int64(x)
-fixed64(x) = float64(x)
-sfixed64(x) = float64(x)
+fixed64(x) = uint64(x)
+sfixed64(x) = int64(x)
 double(x) = float64(x)
-fixed32(x) = float32(x)
-sfixed32(x) = float32(x)
+fixed32(x) = uint32(x)
+sfixed32(x) = int32(x)
 
 print_hdr(tname) = println("testing $tname...")
 


### PR DESCRIPTION
With this change:
- `sfixed32` is serialized as fixed size `Int32`
- `fixed32` as fixed size `UInt32`
- likewise for `sfixed64` and `fixed64`

Prior to this they were getting serialized as `Float32` and `Float64` which was incorrect.

Also code generator generates the `wiretypes` for these specifically since the default `wiretypes` of `Int` and `UInt` are `varints`.