### PR TITLE
protobuild method. deprecate add_field, set_field

### DIFF
--- a/src/codec.jl
+++ b/src/codec.jl
@@ -369,7 +369,7 @@ function meta(typ::Type, required::Array{Symbol,1}, numbers::Array{Int,1}, defau
     cache ? (_metacache[typ] = m) : m
 
     attribs = ProtoMetaAttribs[]
-    names = fieldnames(typ)
+    names = @compat fieldnames(typ)
     types = typ.types
     for fldidx in 1:length(names)
         fldtyp = types[fldidx]
@@ -409,7 +409,7 @@ function filled(obj)
     haskey(_fillcache, oid) && return _fillcache[oid]
 
     fill = Symbol[]
-    for fldname in fieldnames(typeof(obj))
+    for fldname in @compat fieldnames(typeof(obj))
         isdefined(obj, fldname) && push!(fill, fldname)
     end
     if !isimmutable(obj)
@@ -443,7 +443,7 @@ end
 abstract ProtoEnum
 
 function lookup(en::ProtoEnum, val::Integer)
-    for name in fieldnames(typeof(en))
+    for name in @compat fieldnames(typeof(en))
         (val == getfield(en, name)) && return name
     end
     error("Enum $(typeof(en)) has no value: $val")

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -1,6 +1,7 @@
 module ProtoBufTestCodec
 using ProtoBuf
 using Compat
+using Base.Test
 
 import ProtoBuf.meta
 
@@ -101,13 +102,13 @@ function mk_test_meta(fldnum::Int, ptyp::Symbol)
     m
 end
 
-assert_equal{T,U}(::Type{Array{T,1}}, ::Type{Array{U,1}}) = @assert issubtype(T,U) || issubtype(U,T)
-assert_equal(T::Type, U::Type) = @assert issubtype(T,U) || issubtype(U,T)
-assert_equal(val1::Bool, val2::Bool) = @assert val1 == val2
-assert_equal(val1::AbstractString, val2::AbstractString) = @assert val1 == val2
-assert_equal(val1::Number, val2::Number) = @assert val1 == val2
-assert_equal{T<:Number}(val1::Array{T,1}, val2::Array{T,1}) = @assert val1 == val2
-assert_equal{T<:AbstractString}(val1::Array{T,1}, val2::Array{T,1}) = @assert val1 == val2
+assert_equal{T,U}(::Type{Array{T,1}}, ::Type{Array{U,1}}) = @test issubtype(T,U) || issubtype(U,T)
+assert_equal(T::Type, U::Type) = @test issubtype(T,U) || issubtype(U,T)
+assert_equal(val1::Bool, val2::Bool) = @test val1 == val2
+assert_equal(val1::AbstractString, val2::AbstractString) = @test val1 == val2
+assert_equal(val1::Number, val2::Number) = @test val1 == val2
+assert_equal{T<:Number}(val1::Array{T,1}, val2::Array{T,1}) = @test val1 == val2
+assert_equal{T<:AbstractString}(val1::Array{T,1}, val2::Array{T,1}) = @test val1 == val2
 function assert_equal(val1, val2)
     typ1 = typeof(val1)
     typ2 = typeof(val2)
@@ -118,7 +119,7 @@ function assert_equal(val1, val2)
     for fld in n
         fldfill1 = isfilled(val1, fld)
         fldfill2 = isfilled(val2, fld)
-        @assert fldfill1 == fldfill2
+        @test fldfill1 == fldfill2
         fldfill1 && assert_equal(getfield(val1, fld), getfield(val2, fld))
     end
 end
@@ -307,29 +308,29 @@ function test_misc()
     copy!(readfld, testfld)
     assert_equal(readfld, testfld)
 
-    # test add_field
+    # test add_field!
     readfld = TestOptional(TestStr("1"), TestStr(""), Int64[])
     for iVal2 in testfld.iVal2
-        add_field(readfld, :iVal2, iVal2)
+        add_field!(readfld, :iVal2, iVal2)
     end
     assert_equal(readfld, testfld)
 
     tf = TestFilled()
-    @assert !isfilled(tf)
+    @test !isfilled(tf)
     tf.fld1 = TestType("")
     fillset(tf, :fld1)
-    @assert isfilled(tf)
+    @test isfilled(tf)
 end
 
 function test_enums()
     print_hdr("testing enums")
-    @assert getfield(TestEnum, lookup(TestEnum, 0)) == TestEnum.UNIVERSAL
-    @assert getfield(TestEnum, lookup(TestEnum, 1)) == TestEnum.WEB
-    @assert getfield(TestEnum, lookup(TestEnum, 2)) == TestEnum.IMAGES
-    @assert getfield(TestEnum, lookup(TestEnum, 3)) == TestEnum.LOCAL
-    @assert getfield(TestEnum, lookup(TestEnum, 4)) == TestEnum.NEWS
-    @assert getfield(TestEnum, lookup(TestEnum, 5)) == TestEnum.PRODUCTS
-    @assert getfield(TestEnum, lookup(TestEnum, 6)) == TestEnum.VIDEO
+    @test getfield(TestEnum, lookup(TestEnum, 0)) == TestEnum.UNIVERSAL
+    @test getfield(TestEnum, lookup(TestEnum, 1)) == TestEnum.WEB
+    @test getfield(TestEnum, lookup(TestEnum, 2)) == TestEnum.IMAGES
+    @test getfield(TestEnum, lookup(TestEnum, 3)) == TestEnum.LOCAL
+    @test getfield(TestEnum, lookup(TestEnum, 4)) == TestEnum.NEWS
+    @test getfield(TestEnum, lookup(TestEnum, 5)) == TestEnum.PRODUCTS
+    @test getfield(TestEnum, lookup(TestEnum, 6)) == TestEnum.VIDEO
 end
 
 end # module ProtoBufTestCodec

--- a/test/testutilapi.jl
+++ b/test/testutilapi.jl
@@ -1,5 +1,7 @@
 module ProtoBufTestApis
 using ProtoBuf
+using Compat
+using Base.Test
 import ProtoBuf.meta
 
 if isless(Base.VERSION, v"0.4.0-")
@@ -16,26 +18,30 @@ meta(t::Type{TestType}) = meta(t, Symbol[:a], Int[], Dict{Symbol,Any}())
 function test_apis()
     t = TestType()
 
-    @assert !has_field(t, :a)
-    @assert !has_field(t, :b)
+    @test !has_field(t, :a)
+    @test !has_field(t, :b)
 
-    @assert false == try get_field(t, :a); true; catch; false; end
+    @test false == try get_field(t, :a); true; catch; false; end
 
-    set_field(t, :b, true)
-    @assert has_field(t, :b)
-    @assert (get_field(t, :b) == true)
+    set_field!(t, :b, true)
+    @test has_field(t, :b)
+    @test (get_field(t, :b) == true)
 
-    @assert !isinitialized(t)
+    @test !isinitialized(t)
     t.a = "hello"
-    @assert !isinitialized(t)
-    set_field(t, :a, "hello world")
-    @assert isinitialized(t)
-    @assert (get_field(t, :a) ==  "hello world")
+    @test !isinitialized(t)
+    set_field!(t, :a, "hello world")
+    @test isinitialized(t)
+    @test (get_field(t, :a) ==  "hello world")
 
     clear(t, :b)
-    @assert isinitialized(t)
+    @test isinitialized(t)
     clear(t)
-    @assert !isinitialized(t)
+    @test !isinitialized(t)
+
+    t = protobuild(TestType, @compat Dict(:a => "hello", :b => false))
+    @test t.a == "hello"
+    @test t.b == false
 end
 end # module ProtoBufTestApis
 


### PR DESCRIPTION
- deprecate add_field and set_field in favor of add_field! and set_field!
- add protobuild method to make creating protobuf types easier
- better copy! method