### PR TITLE
override hash, isequal, == to consider fill status

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -307,6 +307,10 @@ function generate(outio::IO, errio::IO, dtype::DescriptorProto, scope::Scope, ex
         print(io, isempty(wtypes) ? "ProtoBuf.DEF_WTYPES" : "__wtype_$(dtypename)")
         println(io, ")")
     end
+    # generate hash, equality and isequal methods
+    println(io, "hash(v::$(dtypename)) = ProtoBuf.protohash(v)")
+    println(io, "isequal(v1::$(dtypename), v2::$(dtypename)) = ProtoBuf.protoisequal(v1, v2)")
+    println(io, "==(v1::$(dtypename), v2::$(dtypename)) = ProtoBuf.protoeq(v1, v2)")
 
     println(io, "")
     push!(exports, dtypename)
@@ -433,6 +437,7 @@ function generate(io::IO, errio::IO, protofile::FileDescriptorProto)
     println(io, "using Compat")
     println(io, "using ProtoBuf")
     println(io, "import ProtoBuf.meta")
+    println(io, "import Base: hash, isequal, ==")
     println(io, "")
 
     exports = AbstractString[]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,77 @@
+# utility methods
+
+isinitialized(obj::Any) = isfilled(obj)
+
+set_field!(obj::Any, fld::Symbol, val) = (setfield!(obj, fld, val); fillset(obj, fld); nothing)
+@deprecate set_field(obj::Any, fld::Symbol, val) set_field!(obj, fld, val)
+
+get_field(obj::Any, fld::Symbol) = isfilled(obj, fld) ? getfield(obj, fld) : error("uninitialized field $fld")
+
+clear = fillunset
+
+has_field(obj::Any, fld::Symbol) = isfilled(obj, fld)
+
+function copy!{T}(to::T, from::T)
+    fillunset(to)
+    for name in @compat fieldnames(T)
+        if isfilled(from, name)
+            set_field!(to, name, getfield(from, name))
+        end
+    end
+    nothing
+end
+
+function add_field!(obj::Any, fld::Symbol, val)
+    typ = typeof(obj)
+    attrib = meta(typ).symdict[fld]
+    (attrib.occurrence != 2) && error("$(typ).$(fld) is not a repeating field")
+
+    ptyp = attrib.ptyp
+    jtyp = WIRETYPES[ptyp][4]
+    (ptyp == :obj) && (jtyp = attrib.meta.jtype)
+
+    !isdefined(obj, fld) && setfield!(obj, fld, jtyp[])
+    push!(getfield(obj, fld), val)
+    nothing
+end
+@deprecate add_field(obj::Any, fld::Symbol, val) add_field!(obj, fld, val)
+
+function protobuild{T}(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}())
+    obj = T()
+    for (n,v) in nv
+        fldtyp = fld_type(obj, n)
+        set_field!(obj, n, isa(v, fldtyp) ? v : convert(fldtyp, v))
+    end
+    obj
+end
+
+# hash method that considers fill status of types
+function protohash(v)
+    h = 0
+    for f in fieldnames(v)
+        isfilled(v, f) && (h += hash(getfield(v, f)))
+    end
+    hash(h)
+end
+
+# equality method that considers fill status of types
+function protoeq{T}(v1::T, v2::T)
+    for f in fieldnames(v1)
+        (isfilled(v1, f) == isfilled(v2, f)) || (return false)
+        if isfilled(v1, f)
+            (getfield(v1,f) == getfield(v2,f)) || (return false)
+        end
+    end
+    true
+end
+
+# isequal method that considers fill status of types
+function protoisequal{T}(v1::T, v2::T)
+    for f in fieldnames(v1)
+        (isfilled(v1, f) == isfilled(v2, f)) || (return false)
+        if isfilled(v1, f)
+            isequal(getfield(v1,f), getfield(v2,f)) || (return false)
+        end
+    end
+    true
+end


### PR DESCRIPTION
Since it is possible for ProtoBuf structs not to have some field members filled,
`hash`, `==` and `isequal` should exclude those from the calculation/comparison.