### PR TITLE
allow serialization across similar types

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -7,10 +7,6 @@ import ProtoBuf: meta, logmsg, DEF_REQ, DEF_FNUM, DEF_VAL, DEF_PACK
 
 export gen
 
-if isless(Base.VERSION, v"0.4.0-")
-typealias AbstractString String
-end
-
 include("gen_descriptor_protos.jl")
 include("gen_plugin_protos.jl")
 

--- a/test/compare_ser.jl
+++ b/test/compare_ser.jl
@@ -12,10 +12,7 @@
 
 module ProtoBufCompareSer
 using ProtoBuf
-
-if isless(Base.VERSION, v"0.4.0-")
-typealias AbstractString String
-end
+using Compat
 
 import ProtoBuf.meta
 
@@ -38,12 +35,12 @@ type TestType
     
     function TestType(fill=false)
         !fill && (return new())
-        new(randbool(), 
+        new(@compat(rand(Bool)), 
             rand(-100:100), rand(1:100),
             rand(-100:100), rand(1:100),
-            float32(rand()*100), float64(rand()*100),
+            @compat(Float32(rand()*100)), @compat(Float64(rand()*100)),
             randstring(100), 
-            convert(Array{Bool,1}, randbool(100)),
+            convert(Array{Bool,1}, @compat(rand(Bool,100))),
             rand(Int32, 50),
             rand(Int64, 50),
             rand(Float32, 50),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,3 @@
 include("testcodec.jl")
+include("testtypevers.jl")
 include("testutilapi.jl")

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -5,10 +5,6 @@ using Base.Test
 
 import ProtoBuf.meta
 
-if isless(Base.VERSION, v"0.4.0-")
-typealias AbstractString String
-end
-
 macro _rand_int(T,mx,a)
    esc(quote
        @compat $(T)(round(rand() * $(mx)) + $(a))

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -114,7 +114,7 @@ function assert_equal(val1, val2)
     typ2 = typeof(val2)
     assert_equal(typ1, typ2)
    
-    n = typ1.names
+    n = fieldnames(typ1)
     t = typ1.types 
     for fld in n
         fldfill1 = isfilled(val1, fld)
@@ -138,11 +138,25 @@ function test_types()
     readproto(pb, readval, meta)
     assert_equal(testval, readval)
 
-    let typs = [Int32,Int64,UInt32,UInt64,Bool,Int32,Int64,Uint64,Int64,UInt32,Int32], ptyps=[:int32,:int64,:uint32,:uint64,:bool,:sint32,:sint64,:fixed64,:sfixed64,:fixed32,:sfixed32]
+    let typs = [Int32,Int64,UInt32,UInt64,Int32,Int64,Uint64,Int64,UInt32,Int32], ptyps=[:int32,:int64,:uint32,:uint64,:sint32,:sint64,:fixed64,:sfixed64,:fixed32,:sfixed32]
         for (typ,ptyp) in zip(typs,ptyps)
             print_hdr(ptyp)
             for idx in 1:100
                 testval.val = convert(typ, @_rand_int(UInt32, 10^9, 0))
+                fldnum = @_rand_int(Int, 100, 1)
+                meta = mk_test_meta(fldnum, ptyp)
+                writeproto(pb, testval, meta)
+                readproto(pb, readval, meta)
+                assert_equal(testval, readval)
+            end
+        end
+    end
+
+    let typs = [Bool], ptyps=[:bool]
+        for (typ,ptyp) in zip(typs,ptyps)
+            print_hdr(ptyp)
+            for idx in 1:100
+                testval.val = convert(typ, @_rand_int(UInt32, 1, 0))
                 fldnum = @_rand_int(Int, 100, 1)
                 meta = mk_test_meta(fldnum, ptyp)
                 writeproto(pb, testval, meta)

--- a/test/testtypevers.jl
+++ b/test/testtypevers.jl
@@ -1,0 +1,61 @@
+using ProtoBuf
+
+print_hdr(tname) = println("testing $tname...")
+
+type V1
+    f1::Int32
+    f2::Bool
+    V1() = (a=new(); clear(a); a)
+    V1(f1,f2) = new(f1,f2)
+end
+
+type V2
+    f1::Int64
+    f2::Bool
+    f3::Int64
+    V2() = (a=new(); clear(a); a)
+    V2(f1,f2,f3) = new(f1,f2,f3)
+end
+
+function check_samestruct()
+    iob = PipeBuffer();
+    writeval = V1(1, true);
+    writeproto(iob, writeval);
+    readval = readproto(iob, V1());
+    @assert ProtoBuf.protoeq(readval, writeval)
+
+    iob = PipeBuffer();
+    writeval = V2(1, true, 20);
+    writeproto(iob, writeval);
+    readval = readproto(iob, V2());
+    @assert ProtoBuf.protoeq(readval, writeval)
+end
+
+# write V1, read V2
+# write V2, read V1
+function check_V1_v2()
+    iob = PipeBuffer();
+    writeval = V1(1, true);
+    writeproto(iob, writeval);
+    readval = readproto(iob, V2());
+    checkval = V2(1,true,0)
+    @assert ProtoBuf.protoeq(readval, checkval)
+
+    iob = PipeBuffer();
+    writeval = V2(1, true, 20);
+    writeproto(iob, writeval);
+    readval = readproto(iob, V1());
+    checkval = V1(1,true)
+    @assert ProtoBuf.protoeq(readval, checkval)
+
+    iob = PipeBuffer();
+    writeval = V2(typemax(Int64), true, 20);
+    writeproto(iob, writeval);
+    readval = readproto(iob, V1());
+    checkval = V1(0,true)
+    @assert ProtoBuf.protoeq(readval, checkval)
+end
+
+print_hdr("serialization across type versions")
+check_samestruct()
+check_V1_v2()

--- a/test/testutilapi.jl
+++ b/test/testutilapi.jl
@@ -4,9 +4,7 @@ using Compat
 using Base.Test
 import ProtoBuf.meta
 
-if isless(Base.VERSION, v"0.4.0-")
-typealias AbstractString String
-end
+print_hdr(tname) = println("testing $tname...")
 
 type TestType
     a::AbstractString
@@ -45,5 +43,6 @@ function test_apis()
 end
 end # module ProtoBufTestApis
 
+print_hdr("utility api methods")
 ProtoBufTestApis.test_apis()
 


### PR DESCRIPTION
- Allow skipping of unknown fields
- Allow serialization across different bits types. Overflow causes the field to get the default value (as if the field is missing)
- Compat changes for 0.4
