### PR TITLE
fix #36: Adds '_pb' Postfix to all Module Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Each `.proto` file results in a corresponding `.jl` file, including one each for
 
 If a field name in a message or enum matches a Julia keyword, it is prepended with an `_` character during code generation.
 
+If a package contains a message which has the same name as the package itself, optionally set the `JULIA_PROTOBUF_MODULE_POSTFIX=1` environment variable when running `protoc`, this will append `_pb` to the module names.
+
 ### Julia Type Mapping
 
 .proto Type | Julia Type        | Notes

--- a/plugin/protoc-gen-julia
+++ b/plugin/protoc-gen-julia
@@ -1,1 +1,7 @@
-julia -e 'using ProtoBuf; using ProtoBuf.Gen; gen()'
+#!/bin/bash
+
+if [ ${JULIA_PROTOBUF_MODULE_POSTFIX:-0} -eq 0 ]; then
+    julia -e 'using ProtoBuf; using ProtoBuf.Gen; gen()'
+else
+    julia -e 'using ProtoBuf; using ProtoBuf.Gen; gen()' -- --module-postfix-enabled
+fi

--- a/test/proto/module_type_name_collision.proto
+++ b/test/proto/module_type_name_collision.proto
@@ -1,0 +1,5 @@
+package Foo;
+
+message Foo {
+    required string bar = 1;
+}

--- a/test/testprotoc.sh
+++ b/test/testprotoc.sh
@@ -2,4 +2,5 @@ mkdir -p out
 protoc --proto_path=test/proto --julia_out=out test/proto/t1.proto
 protoc --proto_path=test/proto --julia_out=out test/proto/t2.proto
 protoc --proto_path=test/proto --julia_out=out test/proto/plugin.proto
-protoc --proto_path=test/proto --julia_out=out test/proto/a.proto test/proto/b.proto
+protoc --proto_path=test/proto --julia_out=out test/proto/a.proto test/proto/b.proto && JULIA_LOAD_PATH=out julia -e 'using A, B'
+JULIA_PROTOBUF_MODULE_POSTFIX=1 protoc --proto_path=test/proto --julia_out=out test/proto/module_type_name_collision.proto && JULIA_LOAD_PATH=out julia -e 'using Foo_pb'


### PR DESCRIPTION
This assists in avoid name collisions between packages/modules and messages/types. This is a possible solution for issue #36.