### PR TITLE
generate non empty constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/tanmaykm/ProtoBuf.jl.png)](https://travis-ci.org/tanmaykm/ProtoBuf.jl)
 [![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.3.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.3)
 [![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.4.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.4)
+[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.5.svg)](http://pkg.julialang.org/?pkg=ProtoBuf)
 
 [**Protocol buffers**](https://developers.google.com/protocol-buffers/docs/overview) are a language-neutral, platform-neutral, extensible way of serializing structured data for use in communications protocols, data storage, and more.
 

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -286,7 +286,7 @@ function generate(outio::IO, errio::IO, dtype::DescriptorProto, scope::Scope, ex
             println(io, "    $(fldname)::$typ_name")
         end
     end
-    println(io, "    $(dtypename)() = (o=new(); fillunset(o); o)")
+    println(io, "    $(dtypename)(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)")
     println(io, "end #type $(dtypename)")
 
     # generate the meta for this type if required

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,8 +36,9 @@ function add_field!(obj::Any, fld::Symbol, val)
 end
 @deprecate add_field(obj::Any, fld::Symbol, val) add_field!(obj, fld, val)
 
-function protobuild{T}(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}())
-    obj = T()
+protobuild{T}(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}()) = _protobuild(T(), collect(nv))
+
+function _protobuild{T}(obj::T, nv)
     for (n,v) in nv
         fldtyp = fld_type(obj, n)
         set_field!(obj, n, isa(v, fldtyp) ? v : convert(fldtyp, v))


### PR DESCRIPTION
This changes constructors of generated types to optionally accept keyword arguments specifying field values.
With no keyword arguments, this behaves the same as the earlier generated empty constructor.
When keyword arguments are supplied, this behaves like the `protobuild` utility method.

e.g.:

````
julia> include("A.jl")
A

julia> using A

julia> d = Description()
A.Description(#undef,#undef,0.0)

julia> d = Description(;id="myid", name="myname", date=time())
A.Description("myid","myname",1.450808600240597e9)

````

This is similar but slightly more conventient than using `protobuild`:

````
julia> d = protobuild(Description, Dict(:id=>"myid", :name=>"myname", :date=>time()))
A.Description("myid","myname",1.450808707560326e9)
````

The `protobuild` method can be deprecated in a future update.

ref: #53