### PR TITLE
add `Type` to reserved keywords

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -21,7 +21,8 @@ const _keywords = [
     "try", "catch", "return", "local", "abstract", "function", "macro",
     "ccall", "finally", "typealias", "break", "continue", "type", 
     "global", "module", "using", "import", "export", "const", "let", 
-    "bitstype", "do", "baremodule", "importall", "immutable"
+    "bitstype", "do", "baremodule", "importall", "immutable",
+    "Type"
 ]
 
 _module_postfix = false


### PR DESCRIPTION
Generated code can not redefine `Type` in Julia code.
If the specification contains an entity named `Type`, it will be generated as `_Type`.