### PR TITLE
Enum bugfix

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -271,7 +271,7 @@ function generate(outio::IO, errio::IO, dtype::DescriptorProto, scope::Scope, ex
                     println(errio, "Default values for byte array types are not supported. Field: $(dtypename).$(fldname) has default value [$(field.default_value)]")
                     return
                 else
-                    defval = (field.typ == TYPE_ENUM) ? "$(enum_typ_name).$(field.default_value)" : "$(field.default_value)"
+                    defval = (field.typ == TYPE_ENUM) ? "$(short_type_name(enum_typ_name, depends)).$(field.default_value)" : "$(field.default_value)"
                     push!(defvals, ":$fldname => $defval")
                 end
             end

--- a/test/proto/a.proto
+++ b/test/proto/a.proto
@@ -1,8 +1,14 @@
 
-package A;
+package Base.A;
 
 message Description {
     required string id = 1;
     required string name = 2;
     required double date = 3;
+}
+
+enum Selection {
+    x = 1;
+    y = 2;
+    z = 3;
 }

--- a/test/proto/b.proto
+++ b/test/proto/b.proto
@@ -1,9 +1,10 @@
 
 import "a.proto";
 
-package B;
+package Base.B;
 
 message obj {
-    required A.Description description = 1;
+    required Base.A.Description description = 1;
     repeated string parameters = 2;
+    optional Base.A.Selection selection = 3 [default = z];
 }


### PR DESCRIPTION
For an enum's default value we are currently using the "long" type name, this causes the .jl file to set the default using the a path to the value which isn't valid based on the modules that were imported.  

In the example below the default is set to `Base.A.Selection.z`.  However, since just the modules `A` is brought in with the `using` keyword if we use the "short" type name here we'll appropriately reference the enum default as `Selection.z`.

Note: this only happens with the nested package names like the example below is using (ie: `Base.A` and `Base.B`).