### PR TITLE
enumstr: utility method get name for enum value

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The code generator already generates code for the types it generates overriding 
 - `fillunset(obj::Any)` : mark all fields of this object as not set
 - `fillunset(obj::Any, fld::Symbol)` : mark field fld of object obj as not set
 - `lookup(en::ProtoEnum,val::Integer)` : lookup the name (symbol) corresponding to an enum value
+- `enumstr(enumname, enumvalue::Int32)`: returns a string with the enum field name matching the value
 
 
 ## Generating Code (from .proto files)

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -4,7 +4,7 @@ module ProtoBuf
 
 import Base.show, Base.copy!
 
-export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta, filled, isfilled, fillset, fillunset, show, protobuild
+export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta, filled, isfilled, fillset, fillunset, show, protobuild, enumstr
 export copy!, set_field, set_field!, get_field, clear, add_field, add_field!, has_field, isinitialized
 export ProtoEnum, lookup
 export ProtoServiceException, ProtoRpcChannel, ProtoRpcController, MethodDescriptor, ServiceDescriptor, ProtoService,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,3 +76,10 @@ function protoisequal{T}(v1::T, v2::T)
     end
     true
 end
+
+function enumstr(enumname, t::Int32)
+    for name in fieldnames(enumname)
+        (getfield(enumname, name) == t) && (return string(name))
+    end
+    error("Invalid enum value $t for $(typeof(enumname))")
+end

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -342,6 +342,9 @@ function test_enums()
     @test getfield(TestEnum, lookup(TestEnum, 4)) == TestEnum.NEWS
     @test getfield(TestEnum, lookup(TestEnum, 5)) == TestEnum.PRODUCTS
     @test getfield(TestEnum, lookup(TestEnum, 6)) == TestEnum.VIDEO
+
+    @test enumstr(TestEnum, TestEnum.LOCAL) == "LOCAL"
+    @test_throws ErrorException enumstr(TestEnum, Int32(12))
 end
 
 end # module ProtoBufTestCodec


### PR DESCRIPTION
Makes it easier to show enum values.

e.g. for an enum named `TestEnum` with a value `ENUMVAL1`
````
julia> v = TestEnum.ENUMVAL1;

julia> enumstr(TestEnum, v) == "ENUMVAL1"
true

julia> println(enumstr(TestEnum, v)
ENUMVAL1
````