### PR TITLE
float = Float32

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If a package contains a message which has the same name as the package itself, o
 .proto Type | Julia Type        | Notes
 ---         | ---               | ---
 double      | Float64           | 
-float       | Float64           | 
+float       | Float32           | 
 int32       | Int32             | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead.
 int64       | Int64             | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead.
 uint32      | UInt32            | Uses variable-length encoding.


### PR DESCRIPTION
AFAICT from https://github.com/tanmaykm/ProtoBuf.jl/blob/master/src/codec.jl
The mapping of float is too and from Float32.
(rather than Float64) as indicated in the readme