### PR TITLE
make google wellknown types a submodule (fix #77)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 julia:
-  - 0.3
   - 0.4
   - 0.5
   - nightly
@@ -13,8 +12,10 @@ before_install:
   - sudo apt-get install curl
   - sudo ./test/setup_protoc3.sh
 script:
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("ProtoBuf"))`); Pkg.pin("ProtoBuf"); Pkg.resolve()'
-  - julia -e 'using ProtoBuf; @assert isdefined(:ProtoBuf); @assert typeof(ProtoBuf) === Module'
-  - julia ./test/runtests.jl
-  - PATH=./plugin:$PATH ./test/testprotoc.sh
-  - PATH=./plugin:$PATH PROTOC=/proto3/protobuf-3.0.0-beta-4/install/bin/protoc ./test/testprotoc.sh
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("ProtoBuf"); Pkg.test("ProtoBuf"; coverage=true)'
+  - COVERAGE="--code-coverage=user --inline=no" PATH=./plugin:$PATH ./test/testprotoc.sh
+  - COVERAGE="--code-coverage=user --inline=no" PATH=./plugin:$PATH PROTOC=/proto3/protobuf-3.0.0-beta-4/install/bin/protoc ./test/testprotoc.sh
+after_success:
+  - julia -e 'cd(Pkg.dir("ProtoBuf")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder());'
+  - julia -e 'cd(Pkg.dir("ProtoBuf")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/PROTOC.md
+++ b/PROTOC.md
@@ -41,13 +41,13 @@ map         | Dict              | Can be generated as `Array` of `key-value` by 
 
 ### Well-Known Types
 
-The protocol buffers [well known types](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf) are pre-generated and included in the package as a separate module `google.protobuf`.
+The protocol buffers [well known types](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf) are pre-generated and included in the package as a sub-module `ProtoBuf.google.protobuf`.
 The version of the code included with this package have additional changes to make them compatible with Julia.
 
 You can refer to them in your code after including the following statements:
 ````julia
 using ProtoBuf
-using google.protobuf
+using ProtoBuf.google.protobuf
 ````
 
 While generating code for your `.proto` files that use well-known types, add `ProtoBuf/gen` to the list of includes, e.g.:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![Build Status](https://travis-ci.org/tanmaykm/ProtoBuf.jl.png)](https://travis-ci.org/tanmaykm/ProtoBuf.jl)
 [![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.3.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.3)
 [![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.4.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.4)
-[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.5.svg)](http://pkg.julialang.org/?pkg=ProtoBuf)
+[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.5.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.5)
+[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.6.svg)](http://pkg.julialang.org/?pkg=ProtoBuf)
+
+[![Coverage Status](https://coveralls.io/repos/github/tanmaykm/ProtoBuf.jl/badge.svg?branch=master)](https://coveralls.io/github/tanmaykm/ProtoBuf.jl?branch=master)
 
 [**Protocol buffers**](https://developers.google.com/protocol-buffers/docs/overview) are a language-neutral, platform-neutral, extensible way of serializing structured data for use in communications protocols, data storage, and more.
 

--- a/plugin/protoc-gen-julia
+++ b/plugin/protoc-gen-julia
@@ -12,7 +12,7 @@ fi
 
 if [ -z ${FLAGS} ]
 then
-    julia -e 'using ProtoBuf; using ProtoBuf.Gen; gen()'
+    julia ${COVERAGE} -e 'using ProtoBuf; using ProtoBuf.Gen; gen()'
 else
-    julia -e 'using ProtoBuf; using ProtoBuf.Gen; gen()' -- ${FLAGS}
+    julia ${COVERAGE} -e 'using ProtoBuf; using ProtoBuf.Gen; gen()' -- ${FLAGS}
 fi

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -53,9 +53,9 @@ include("google/google.jl")
 include("gen.jl")
 include("utils.jl")
 
-end # module
-
 # Include Google ProtoBuf well known types (https://developers.google.com/protocol-buffers/docs/reference/google.protobuf).
-# These are part of the `google.protobuf` module and are included automatically by the code generator.
-# For hand coded modules, include them with: `using ProtoBuf; using google.protobuf`.
+# These are part of the `google.protobuf` sub-module and are included automatically by the code generator.
+# For hand coded modules, include them with: `using ProtoBuf; using ProtoBuf.google.protobuf`.
 include("google/wellknown.jl")
+
+end # module

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -21,6 +21,9 @@ const _packages = Dict{AbstractString,AbstractString}()
 # maps protofile name to array of imported protofiles
 const protofile_imports = Dict()
 
+# Treat Google Proto3 extensions specially as they are built into ProtoBuf.jl (for issue #77)
+const GOOGLE_PROTO3_EXTENSIONS = "google.protobuf"
+
 const _keywords = [
     "if", "else", "elseif", "while", "for", "begin", "end", "quote", 
     "try", "catch", "return", "local", "abstract", "function", "macro",
@@ -499,6 +502,9 @@ function generate(io::IO, errio::IO, protofile::FileDescriptorProto)
         for dependency in using_pkgs
             (fullscopename == dependency) && continue
             !isempty(parentscope) && startswith(dependency, parentscope) && (dependency = ".$(dependency[length(parentscope)+1:end])")
+            if dependency == GOOGLE_PROTO3_EXTENSIONS
+                dependency = "ProtoBuf." * dependency
+            end
             println(io, "using $dependency")
         end
     end

--- a/test/testwellknown.jl
+++ b/test/testwellknown.jl
@@ -1,6 +1,6 @@
 module ProtoBufTestWellKnown
 using ProtoBuf
-using google.protobuf
+using ProtoBuf.google.protobuf
 using Base.Test
 using Compat
 


### PR DESCRIPTION
This makes code generated for Google's well-known type extensions a sub-module of ProtoBuf.

Julia protoc now treats them specially and imports the ProtoBuf supplied sub-module when encountered.

Also remove Julia 0.3 support, update CI and coverage.

Fixes #77