### PR TITLE
fix negative int32 varint format

### DIFF
--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -168,6 +168,20 @@ function test_types()
         end
     end
 
+    let typs = [Int32,Int64,Int32,Int64], ptyps=[:int32,:int64,:sint32,:sint64]
+        for (typ,ptyp) in zip(typs,ptyps)
+            print_hdr(ptyp)
+            for idx in 1:100
+                testval.val = convert(typ, -1 * @_rand_int(Int32, 10^9, 0))
+                fldnum = @_rand_int(Int, 100, 1)
+                meta = mk_test_meta(fldnum, ptyp)
+                writeproto(pb, testval, meta)
+                readproto(pb, readval, meta)
+                assert_equal(testval, readval)
+            end
+        end
+    end
+
     let typs = [Bool], ptyps=[:bool]
         for (typ,ptyp) in zip(typs,ptyps)
             print_hdr(ptyp)

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -182,6 +182,15 @@ function test_types()
         end
     end
 
+    print_hdr("varint overflow...")
+    ProtoBuf._write_uleb(pb, -1)
+    @test ProtoBuf._read_uleb(pb, Int8) == 0
+    ProtoBuf._write_uleb(pb, 1)
+    @test ProtoBuf._read_uleb(pb, Int8) == 1
+    write(pb, 0xff)
+    ProtoBuf._write_uleb(pb, -1)
+    @test ProtoBuf._read_uleb(pb, Int32) == 0
+
     let typs = [Bool], ptyps=[:bool]
         for (typ,ptyp) in zip(typs,ptyps)
             print_hdr(ptyp)

--- a/test/testtypevers.jl
+++ b/test/testtypevers.jl
@@ -52,7 +52,7 @@ function check_V1_v2()
     writeval = V2(typemax(Int64), true, 20);
     writeproto(iob, writeval);
     readval = readproto(iob, V1());
-    checkval = V1(0,true)
+    checkval = V1(-1,true)  # overflow can't be detected as negative int32 is sign extended for serialization
     @assert ProtoBuf.protoeq(readval, checkval)
 end
 


### PR DESCRIPTION
fixes #86

Strangely, it looks like both negative `int32` and `int64` should encode to 10 bytes.

from https://developers.google.com/protocol-buffers/docs/encoding:
> if you use int32 or int64 as the type for a negative number, the resulting varint is always ten bytes long – it is, effectively, treated like a very large unsigned integer.

This alters int32 varint
- reading to accept both 10 and 5 byte serialization formats (like the C implementation and unlike python)
- writing to always serialize 10 bytes